### PR TITLE
Compatibility with FAR

### DIFF
--- a/Release/AirplanePlus/FAR_AirplanePlusCompatibilityPatch.cfg
+++ b/Release/AirplanePlus/FAR_AirplanePlusCompatibilityPatch.cfg
@@ -1,0 +1,1037 @@
+// remove propellers from voxel generation
+//early
+@PART[51prop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+	}
+}
+
+@PART[chaikaprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = nosedisc
+		ignoreTransform = shaftdisc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+	}
+}
+
+@PART[fokkerprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = disc_placeholder
+		ignoreTransform = propeller
+		ignoreTransform = blade3
+		ignoreTransform = blade4
+		ignoreTransform = blade5
+	}
+}
+
+@PART[hawkerprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+	}
+}
+
+@PART[spadprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = propeller
+	}
+}
+
+// pre modern
+
+@PART[109Prop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+	}
+}
+
+@PART[corsairprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+	}
+}
+
+@PART[duplexcyclone]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+		ignoreTransform = blade4
+	}
+}
+
+@PART[fighterProp]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+	}
+}
+
+@PART[merlin]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+		ignoreTransform = blade4
+	}
+}
+
+@PART[spitfiremerlin]:AFTER[FerramAerospaceResearch]
+{	
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+		ignoreTransform = blade4
+		ignoreTransform = blade5
+	}
+}
+
+@PART[yakprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+	}
+}
+
+@PART[zeroprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+	}
+}
+
+//modern
+
+@PART[152Prop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+	}
+}
+
+@PART[609prop]:AFTER[FerramAerospaceResearch]
+{
+	%mirrorRefAxis = 0, 0, 1
+	%node_attach = 0.00, 0.00, 0.00, 1.0, 90.0, 0.0, 1
+	
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = disccollider
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+	}
+	
+}
+
+@PART[herculesprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+		ignoreTransform = blade4
+	}
+}
+
+@PART[KP12]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = fdisc
+		ignoreTransform = fblade1
+		ignoreTransform = fblade2
+		ignoreTransform = fblade3
+		ignoreTransform = fblade4
+		ignoreTransform = rdisc
+		ignoreTransform = rblade1
+		ignoreTransform = rblade2
+		ignoreTransform = rblade3
+		ignoreTransform = rblade4
+	}
+}
+
+@PART[predatorprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+	}
+}
+
+@PART[tbmProp]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = nblade1
+		ignoreTransform = nblade2
+		ignoreTransform = nblade3
+		ignoreTransform = nblade4
+		ignoreTransform = nblade5
+		ignoreTransform = rblade1
+		ignoreTransform = rblade2
+		ignoreTransform = rblade3
+		ignoreTransform = rblade4
+		ignoreTransform = rblade5
+	}
+}
+
+//Rotorwing
+
+@PART[bellprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+	}
+}
+
+@PART[belltail]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+	}
+}
+
+@PART[blackhawkprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+		ignoreTransform = blade4
+	}
+}
+
+@PART[chinookprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+	}
+}
+
+@PART[coaxialprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = ddisc
+		ignoreTransform = dblade
+		ignoreTransform = udisc
+		ignoreTransform = ublade
+	}
+}
+
+@PART[hipprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+		ignoreTransform = blade4
+		ignoreTransform = blade5
+	}
+}
+
+@PART[hiptail]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+	}
+}
+
+@PART[hueyprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = rods
+	}
+}
+
+@PART[hueytail]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = rods
+	}
+}
+
+@PART[powerprop]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = powerdisc
+		ignoreTransform = blademesh
+	}
+}
+
+@PART[powertail]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseMeshes = true
+		ignoreTransform = disc
+		ignoreTransform = blade1
+		ignoreTransform = blade2
+		ignoreTransform = blade3
+		ignoreTransform = blade4
+	}
+}
+
+//remove lifting values for some non wing parts like cockpits
+@PART[144cockpit]:FOR[FerramAerospaceResearch]
+{
+	!MODULE[ModuleLiftingSurface] { }
+}
+
+@PART[falconcockpit]:FOR[FerramAerospaceResearch]
+{
+	!MODULE[ModuleLiftingSurface] { }
+}
+
+@PART[mk2hAdapter]:FOR[FerramAerospaceResearch]
+{
+	!MODULE[ModuleLiftingSurface] { }
+}
+
+@PART[mk2hLiquid]:FOR[FerramAerospaceResearch]
+{
+	!MODULE[ModuleLiftingSurface] { }
+}
+
+@PART[mk2hboom]:FOR[FerramAerospaceResearch]
+{
+	!MODULE[ModuleLiftingSurface] { }
+}
+
+@PART[mk2mk2h]:FOR[FerramAerospaceResearch]
+{
+	!MODULE[ModuleLiftingSurface] { }
+}
+
+// add FAR wing configurations
+
+@PART[hanglel]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 2 // 2n rc
+		MidChordSweep = 0
+		b_2 = 0.46
+		TaperRatio = 1
+		%rootMidChordOffsetFromOrig = 0.2, 0.0, 0.0
+	}
+}
+
+@PART[hangles]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 1
+		MidChordSweep = 0
+		b_2 = 0.46
+		TaperRatio = 1
+		%rootMidChordOffsetFromOrig = 0.2, 0.0, 0.0
+	}
+}
+
+@PART[vanglel]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 1.3
+		MidChordSweep = 0
+		b_2 = 0.18
+		TaperRatio = 1
+		%rootMidChordOffsetFromOrig = 0.05, 0.0, 0.0
+	}
+}
+
+@PART[vangles]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 0.82
+		MidChordSweep = 0
+		b_2 = 0.18
+		TaperRatio = 1
+		%rootMidChordOffsetFromOrig = 0.05, 0.0, 0.0
+	}
+}
+
+@PART[bigwing]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 1.9 //2.34m 1.37m
+		MidChordSweep = -5.2
+		b_2 = 11.15
+		TaperRatio = 0.58
+		%rootMidChordOffsetFromOrig = 0.1, -0.47, 0
+	}
+}
+
+@PART[hlfSrf]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+	@ctrlSurfaceRange = 0
+	@ctrlSurfaceArea = 0
+    !MODULE[ModuleControlSurface] {}
+	MODULE
+	{
+		name = FARControllableSurface
+        MAC = 0.519
+		MidChordSweep = 0
+		b_2 = 0.91
+        TaperRatio = 1
+        nonSideAttach = 1
+        maxdeflect = 20
+        ctrlSurfFrac = 1
+		transformName = elevon
+		%rootMidChordOffsetFromOrig = 0.0, 0.1, 0.0
+	}
+}
+
+@PART[fatwing0]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 1.37
+		MidChordSweep = 0
+		b_2 = 3.89
+		TaperRatio = 1
+		%rootMidChordOffsetFromOrig = 0.2, 0.0, 0.0
+	}
+}
+
+@PART[fatwing1]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 3.87
+		MidChordSweep = 0
+		b_2 = 1.37
+		TaperRatio = 1
+		%rootMidChordOffsetFromOrig = 0.2, 0.0, 0.0
+	}
+}
+
+@PART[fatwing2]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 0.97 //1.37m 0.37m
+		MidChordSweep = -16
+		b_2 = 3.87
+		TaperRatio = 0.27
+		%rootMidChordOffsetFromOrig = 0.55, -0.25, 0.0
+	}
+}
+
+@PART[fatwing3]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 2.58 //3.87m 0m
+		MidChordSweep = 72
+		b_2 = 1.37
+		TaperRatio = 0
+		%rootMidChordOffsetFromOrig = 0.15, 0.8, 0.0
+	}
+}
+
+@PART[fatwing4]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 3.87 
+		MidChordSweep = 0
+		b_2 = 0.88
+		TaperRatio = 1
+		%rootMidChordOffsetFromOrig = 0.2, 0.2, 0.0
+	}
+}
+
+@PART[fatwing5]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 2.58 //3.87 m 0m
+		MidChordSweep = 79
+		b_2 = 0.88
+		TaperRatio = 0
+		%rootMidChordOffsetFromOrig = 0.14, 0.85, 0.0
+	}
+}
+
+@PART[fatwing6]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 0.57 //0.86 m 0m
+		MidChordSweep = -10
+		b_2 = 3.88
+		TaperRatio = 0
+		%rootMidChordOffsetFromOrig = 0.0, -0.14, 0.0
+	}
+}
+
+@PART[migfin]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleControlSurface] {}
+	MODULE
+	{
+		name = FARControllableSurface
+		MAC = 2.04  // Tip = 0.45m | Root = 3m
+		MidChordSweep = 26.4 // 49* 3.8*
+		b_2 = 2.22 
+		TaperRatio = 0.15  
+		maxdeflect = 20  
+		ctrlSurfFrac = 0.19
+		%rootMidChordOffsetFromOrig = 0.75, 0.35, 0.0
+	}
+}
+
+@PART[warhawkfin]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleControlSurface] {}
+	MODULE
+	{
+		name = FARControllableSurface
+		MAC = 1.47  // Tip = .75m | Root = 2m
+		MidChordSweep = 6 // 23* -11*
+		b_2 = 2.05 
+		TaperRatio = 0.38  
+		maxdeflect = 20  
+		ctrlSurfFrac = 0.45
+		transformName = ctrlSrf
+		%rootMidChordOffsetFromOrig = 0.9, 0.13, 0
+	}
+}
+
+
+// FAR supports only one controllable surface we have to combine both slats together
+@PART[doublefowlerflap]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleAeroSurface] {}
+	!MODULE[ModuleAeroSurface] {} //we have to remove both surfaces
+	MODULE
+	{
+		name = FARControllableSurface
+		MAC = 1.37
+		MidChordSweep = 0
+		b_2 = 3.6 
+		TaperRatio = 1
+		nonSideAttach = 1  
+		maxdeflect = 15  
+		ctrlSurfFrac = 1
+		transformName = hinge
+		%rootMidChordOffsetFromOrig = 0, 0.3, 0.0
+	}
+}
+
+@PART[fowlerflap]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleAeroSurface] {}
+	MODULE
+	{
+		name = FARControllableSurface
+		MAC = 0.74
+		MidChordSweep = 0
+		b_2 = 1.82 
+		TaperRatio = 1
+		nonSideAttach = 1  
+		maxdeflect = 15  
+		ctrlSurfFrac = 1
+		transformName = hinge
+		%rootMidChordOffsetFromOrig = 0, 0.17, 0.0
+	}
+}
+
+@PART[kruegerflap]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleAeroSurface] {}
+	MODULE
+	{
+		name = FARControllableSurface
+		MAC = 0.37
+		MidChordSweep = 0
+		b_2 = 1.67 
+		TaperRatio = 1
+		nonSideAttach = 1  
+		maxdeflect = 15  
+		ctrlSurfFrac = 1
+		transformName = flap
+		%rootMidChordOffsetFromOrig = 0.0, 0.1, 0.0
+	}
+}
+
+@PART[spoilerflap]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleAeroSurface] {}
+	MODULE
+	{
+		name = FARControllableSurface
+		MAC = 0.47
+		MidChordSweep = 0
+		b_2 = 3.6 
+		TaperRatio = 1
+		nonSideAttach = 1  
+		maxdeflect = 15  
+		ctrlSurfFrac = 1
+		transformName = hinge
+		%rootMidChordOffsetFromOrig = 0, 0.1, 0.0
+	}
+}
+
+@PART[straightslat]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleAeroSurface] {}
+	MODULE
+	{
+		name = FARControllableSurface
+		MAC = 0.36
+		MidChordSweep = 0
+		b_2 = 1.83
+		TaperRatio = 1
+		nonSideAttach = 1  
+		maxdeflect = 15  
+		ctrlSurfFrac = 1
+		transformName = straight
+		%rootMidChordOffsetFromOrig = 0.0, 0.1, 0.0
+	}
+}
+
+@PART[roundwinglet]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleControlSurface] {}
+	MODULE
+	{
+		name = FARControllableSurface
+		MAC = 1.27  // Tip = 0.7m | Root = 1.7m
+		MidChordSweep = 3.5 // 13* -6*
+		b_2 = 1.5 
+		TaperRatio = 0.4  
+		maxdeflect = 20  
+		ctrlSurfFrac = 0.45
+		transformName = obj_ctrlSrf
+		%rootMidChordOffsetFromOrig = 0.35, 0.15, 0.0
+	}
+}
+
+@PART[elevon2b]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+	@ctrlSurfaceRange = 0
+	@ctrlSurfaceArea = 0
+    !MODULE[ModuleControlSurface] {}
+	MODULE
+	{
+		name = FARControllableSurface
+        MAC = 0.74
+		MidChordSweep = 0
+		b_2 = 1.82
+        TaperRatio = 1
+        nonSideAttach = 1
+        maxdeflect = 20
+        ctrlSurfFrac = 1
+		transformName = ctrlSrf
+		%rootMidChordOffsetFromOrig = 0.0, 0.16, 0.0
+	}
+}
+
+@PART[smallwingConnector1]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 1.3
+		MidChordSweep = 0
+		b_2 = 1.05
+		TaperRatio = 1
+	}
+}
+
+@PART[smallwingConnector2]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 2
+		MidChordSweep = 0
+		b_2 = 0.84
+		TaperRatio = 1
+		%rootMidChordOffsetFromOrig = 0.20, 0.0, 0.0
+	}
+}
+
+@PART[smallwingConnector3]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 0.85
+		MidChordSweep = 0
+		b_2 = 2
+		TaperRatio = 1
+	}
+}
+
+@PART[smallwingConnector4]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 1.1 // 1.31m 0.85m
+		MidChordSweep = -6.5 //0* -13*
+		b_2 = 2
+		TaperRatio = 0.65
+	}
+}
+
+@PART[smallwingConnector5]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 0.64 // 0.37m 0.85m
+		MidChordSweep = 7 //14* 0*
+		b_2 = 2
+		TaperRatio = 0.43
+	}
+}
+
+@PART[smallwingConnector6]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 1.33 // 0m 2m
+		MidChordSweep = -35.5 //0* -71*
+		b_2 = 0.86
+		TaperRatio = 0
+	}
+}
+
+@PART[smallwingConnectortip]:FOR[FerramAerospaceResearch]
+{
+	@module = Part
+	@maximum_drag = 0
+	@minimum_drag = 0
+	@angularDrag = 0
+	@dragCoeff = 0
+	@deflectionLiftCoeff = 0
+    !MODULE[ModuleLiftingSurface] {}
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 0.99 // 0.57m 1.31m
+		MidChordSweep = -8.5 //28* -45*
+		b_2 = 0.6
+		TaperRatio = 0.44
+	}
+}


### PR DESCRIPTION
Patch to make Airplane Plus parts compatible with FAR
- Added FAR configs for all wings
- Removed Prop blades from Voxelation
- Limitations Double slotted Fowler Flpas act as one surface as FAR does not support multiple Control surfaces within a single part
- KT6C "Kitty" Turboshaft Engine kept its default control surface as it would not work as a FAR control surface